### PR TITLE
chore(plugin): Use original resolvers as fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ after_success:
 
 before_deploy:
   - export ZIP_FILE=$(ls | grep .tgz)
+  - export VERSION_TAG=$(cat package.json | jq .version -r)
+  - git tag $VERSION_TAG
 
 deploy:
   - provider: releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contribution quick guide
+
+## Clone the repo
+
+```bash
+git clone git@github.com:pandomic/serverless-offline-variables.git
+```
+
+## Install dependencies
+
+```bash
+npm install
+```
+
+or
+
+```
+yarn install
+```
+
+## Do your changes
+
+1. Keep things stupid simple
+2. Try to keep the code clean, nice and readable
+3. Test the core functionality
+4. Once you are done, please check the code using
+
+```
+npm run lint
+npm run test
+```
+
+## Commit your changes
+
+We use the next format for commit headers:
+```
+<type>(<scope>): <Short description>
+```
+
+where type could be:
+* chore - regular changes
+* feat - new features
+* fix - fixes
+
+For example:
+```
+chore(docs): Update documentation
+```
+
+## Open PR
+
+Once you are done with everything, feel free to propose your changes by opening a new PR.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ custom:
 By default plugin will first try to locate your variable in `.env` file
 (or in the file you specified), and only then under the `variables` section.
 
+If `serverless-offline-variables` fails to locate a variable it falls back
+to original resolver.
+
 ## Contributions
 
 You are welcome to create pull requests to improve the project. Please check out
-the [contributing](https://github.com/pandomic/serverless-offline-variables/blob/master/CONTRIBUTING.md)
+the [contribution](https://github.com/pandomic/serverless-offline-variables/blob/master/CONTRIBUTING.md)
 quick guide to get started.
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-variables",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Mock serverless variables in offline or localstack mode",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -45,7 +45,7 @@ const createServerless = (): ServerlessType => ({
   }
 });
 
-test('replaces original resolvers', async () => {
+test('replaces original resolvers but leaves unknown values', async () => {
   const serverless = createServerless();
 
   new Plugin(serverless, { stage: 'local', region: '' });
@@ -67,10 +67,20 @@ test('replaces original resolvers', async () => {
   const cfValue = cfResolver && await cfResolver.resolver('cf:variable');
   const envValue = envResolver && await envResolver.resolver('env:variable');
 
+  const unknownSsmValue = ssmResolver && await ssmResolver.resolver('ssm:unknown-variable');
+  const unknownS3Value = s3Resolver && await s3Resolver.resolver('s3:unknown-variable');
+  const unknownCfValue = cfResolver && await cfResolver.resolver('cf:unknown-variable');
+  const unknownEnvValue = envResolver && await envResolver.resolver('env:unknown-variable');
+
   expect(ssmValue).toEqual('replaced-ssm');
   expect(s3Value).toEqual('replaced-s3');
   expect(cfValue).toEqual('replaced-cf');
   expect(envValue).toEqual('replaced-env');
+
+  expect(unknownSsmValue).toEqual('original-ssm');
+  expect(unknownS3Value).toEqual('original-s3');
+  expect(unknownCfValue).toEqual('original-cf');
+  expect(unknownEnvValue).toEqual('original-env');
 });
 
 test('does nothing when stage does not match', async () => {

--- a/src/resolvers.test.ts
+++ b/src/resolvers.test.ts
@@ -19,3 +19,17 @@ describe('isWatched()', () => {
     expect(isWatched(resolver)).toEqual(false);
   });
 });
+
+describe('extractFeature()', () => {
+  test('returns feature for named resolver', () => {
+    const resolver = { serviceName: 'SSM', regex: /.+/, resolver: async () => null };
+
+    expect(extractFeature(resolver)).toEqual('SSM');
+  });
+
+  test('returns feature for resolver with regex', () => {
+    const resolver = { regex: /^env:/, resolver: async () => null };
+
+    expect(extractFeature(resolver)).toEqual('/^env:/');
+  });
+});

--- a/src/resolvers.test.ts
+++ b/src/resolvers.test.ts
@@ -1,0 +1,21 @@
+import { isWatched, extractFeature } from './resolvers';
+
+describe('isWatched()', () => {
+  test('returns true for watched resolver by name', () => {
+    const resolver = { serviceName: 'SSM', regex: /.+/, resolver: async () => null };
+
+    expect(isWatched(resolver)).toEqual(true);
+  });
+
+  test('returns true for watched resolver by regex', () => {
+    const resolver = { regex: /^env:/, resolver: async () => null };
+
+    expect(isWatched(resolver)).toEqual(true);
+  });
+
+  test('returns false for unknown resolver', () => {
+    const resolver = { regex: /self:(.+)/, resolver: async () => null };
+
+    expect(isWatched(resolver)).toEqual(false);
+  });
+});

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,0 +1,11 @@
+import { VariableResolver } from './types';
+
+const WATCHED_SOURCE_NAMES = ['CloudFormation', 'SSM', 'S3'];
+const WATCHED_SOURCE_REGEX = ['env:'];
+
+export const extractFeature = (resolver: VariableResolver): string =>
+  resolver.serviceName || resolver.regex.toString();
+
+export const isWatched = (resolver: VariableResolver): boolean =>
+  WATCHED_SOURCE_NAMES.includes(extractFeature(resolver)) ||
+  WATCHED_SOURCE_REGEX.some((regStr) => extractFeature(resolver).includes(regStr));

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,12 @@ import * as ServerlessType from "serverless";
 
 export { default as Plugin } from "serverless/classes/Plugin";
 
+export type Resolver = (variable: string) =>
+  Promise<string | null | undefined>;
+
 export type VariableResolver = {
   regex: RegExp,
-  resolver: (variable: string) => Promise<string | null | undefined>,
+  resolver: Resolver,
   isDisabledAtPrepopulation?: boolean,
   serviceName?: string
 }


### PR DESCRIPTION
Use original resolvers as fallback in case `serverless-offline-variables` fails to locate variables.